### PR TITLE
fix: Add missing gradle.properties file

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,31 @@
+# Project-wide Gradle settings.
+
+# IDE (e.g. Android Studio) users:
+# Settings specified in this file will override any Gradle settings
+# configured through the IDE.
+
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+
+# Specifies the JVM arguments used for the Gradle daemon.
+# The daemon is an optimization Gradle uses to keep build info hot in memory.
+# Setting Xmx to a higher value can speed up builds if you have enough RAM.
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app's APK
+# https://developer.android.com/jetpack/androidx/
+android.useAndroidX=true
+
+# Automatically convert third-party libraries to use AndroidX
+android.enableJetifier=true
+
+# Kotlin code style for auto-formatting
+# kotlin.code.style=official
+# Or, if you manage Kotlin version here (though often it's in build.gradle ext block)
+# kotlinVersion=1.8.20


### PR DESCRIPTION
This file includes project-wide Gradle settings such as JVM arguments for the Gradle daemon and AndroidX flags.