### PR TITLE
Fix unresolved references in Kotlin code

### DIFF
--- a/android_build_fix_summary.md
+++ b/android_build_fix_summary.md
@@ -1,0 +1,63 @@
+# Android Build Fix Summary - IdleRPG Project
+
+## Problem Resolved
+The Android build was failing with 26 compilation errors in `GameEngine.kt` due to unresolved references to `WeaponType` and `ArmorType` enums.
+
+## Root Cause
+Missing import statements in `app/src/main/java/com/example/idlerpg/game/GameEngine.kt` for enum types defined in `app/src/main/java/com/example/idlerpg/models/GearItem.kt`.
+
+## Solution Applied
+Added the following import statements to `GameEngine.kt`:
+
+```kotlin
+import com.example.idlerpg.models.ArmorType
+import com.example.idlerpg.models.WeaponType
+```
+
+## Files Modified
+- **File**: `app/src/main/java/com/example/idlerpg/game/GameEngine.kt`
+- **Lines**: Added imports at lines 3 and 9 respectively
+- **Change**: Added missing enum imports in alphabetical order with existing model imports
+
+## Affected Code Sections
+The fix resolves compilation errors in the following areas of `GameEngine.kt`:
+
+### Shop Item Definitions (Lines 31-66)
+- Weapon items using `WeaponType.SWORD`, `WeaponType.DAGGER`, `WeaponType.TWO_HANDED`
+- Armor items using `ArmorType.LIGHT`, `ArmorType.MEDIUM`, `ArmorType.HEAVY`
+
+### Helper Methods (Lines 639-644)
+- `getWeaponsByType()` method parameter and filtering
+- `getArmorByType()` method parameter and filtering
+
+## Enum Definitions Verified
+**WeaponType** (in GearItem.kt):
+- SWORD
+- DAGGER  
+- TWO_HANDED
+
+**ArmorType** (in GearItem.kt):
+- LIGHT
+- MEDIUM
+- HEAVY
+
+## Build Status
+✅ **RESOLVED**: All 26 compilation errors should now be fixed
+- Import statements properly added
+- Enum references now resolvable
+- Code structure and logic unchanged
+
+## Testing Notes
+The build environment lacks gradle wrapper and gradle installation, preventing immediate build verification. However, the fix addresses the core issue identified in the compilation errors.
+
+## Project Structure Confirmed
+```
+app/src/main/java/com/example/idlerpg/
+├── game/
+│   └── GameEngine.kt (✅ Fixed)
+├── models/
+│   └── GearItem.kt (Contains enum definitions)
+└── [other components]
+```
+
+The fix maintains proper Android project structure and Kotlin package organization.

--- a/app/src/main/java/com/example/idlerpg/game/GameEngine.kt
+++ b/app/src/main/java/com/example/idlerpg/game/GameEngine.kt
@@ -1,10 +1,12 @@
 package com.example.idlerpg.game
 
+import com.example.idlerpg.models.ArmorType
 import com.example.idlerpg.models.GearItem
 import com.example.idlerpg.models.ItemType
 import com.example.idlerpg.models.Monster
 import com.example.idlerpg.models.MonsterAbility
 import com.example.idlerpg.models.Player
+import com.example.idlerpg.models.WeaponType
 import kotlin.math.max
 import kotlin.math.pow
 import kotlin.random.Random


### PR DESCRIPTION
Add missing imports for `WeaponType` and `ArmorType` to resolve compilation errors in `GameEngine.kt`.